### PR TITLE
Correlators

### DIFF
--- a/src/X6_1000.cpp
+++ b/src/X6_1000.cpp
@@ -1069,6 +1069,7 @@ vector<vector<int>> combinations(int n, int r) {
     vector<vector<int>> c;
     vector<int> s(r);
     int i;
+    if (n < r) return c;
     for (i = 0; i < r; i++)
         s[i] = i;
     c.push_back(s);

--- a/src/X6_1000.cpp
+++ b/src/X6_1000.cpp
@@ -855,12 +855,9 @@ void Accumulator::snapshot_variance(double * buf) {
         }
     } else {
         // construct complex vector of data
-        vector<std::complex<int64_t>> cvec(data_.size()/2);
-        for (int i = 0; i < data_.size()/2; i++) {
-            cvec[i] = std::complex<int64_t>(data_[2*i], data_[2*i+1]);
-        }
+        std::complex<double>* cvec = reinterpret_cast<std::complex<double> *>(data_.data());
         // calculate 3 components of variance
-        for(size_t ct=0; ct < cvec.size(); ct++) {
+        for(size_t ct=0; ct < data_.size()/2; ct++) {
             buf[3*ct] = static_cast<double>(data2_[3*ct] - cvec[ct].real()*cvec[ct].real()/N) / scale;
             buf[3*ct+1] = static_cast<double>(data2_[3*ct+1] - cvec[ct].imag()*cvec[ct].imag()/N) / scale;
             buf[3*ct+2] = static_cast<double>(data2_[3*ct+2] - cvec[ct].real()*cvec[ct].imag()/N) / scale;
@@ -886,9 +883,8 @@ void Accumulator::accumulate(const AccessDatagram<T> & buffer) {
             return a + b*b;
         });
     } else {
-        // data is complex: real part is section from [0, recordLength_/2],
-        // imaginary part goes from [recordLength_/2 + 1, recordLength_].
-        // form a complex vector from the input buffer and square it
+        // data is complex: real/imaginary are interleaved every other point
+        // form a complex vector from the input buffer
         vector<std::complex<int64_t>> cvec(recordLength_/2);
         for (int i = 0; i < recordLength_/2; i++) {
             cvec[i] = std::complex<int64_t>(buffer[2*i], buffer[2*i+1]);

--- a/src/X6_1000.cpp
+++ b/src/X6_1000.cpp
@@ -828,14 +828,14 @@ size_t Accumulator::get_buffer_size() {
 
 void Accumulator::snapshot(double * buf) {
     /* Copies current data into a *preallocated* buffer*/
-    double scale = max(static_cast<int>(recordsTaken), 1) / (numSegments_*numWaveforms_) * fixed_to_float_;
+    double scale = max(static_cast<int>(recordsTaken), 1) / numSegments_ * fixed_to_float_;
     for(size_t ct=0; ct < data_.size(); ct++){
         buf[ct] = static_cast<double>(data_[ct]) / scale;
     }
 }
 
 void Accumulator::snapshot_variance(double * buf) {
-    int64_t N = max(static_cast<int>(recordsTaken / (numSegments_*numWaveforms_)), 1);
+    int64_t N = max(static_cast<int>(recordsTaken / numSegments_), 1);
     double scale = (N-1) * fixed_to_float_ * fixed_to_float_;
 
     if (N == 0) {

--- a/src/X6_1000.cpp
+++ b/src/X6_1000.cpp
@@ -828,7 +828,7 @@ int Accumulator::fixed_to_float(const Channel & chan) {
             break;
         case DEMOD:
         case RESULT:
-            return 1 << 14; // sfix16_14 from DDC
+            return 1 << 14; // sfix16_14 from DDC or sfix32_14 from DecisionEngine
             break;
     }
 }
@@ -855,7 +855,7 @@ void Accumulator::snapshot_variance(double * buf) {
         }
     } else {
         // construct complex vector of data
-        std::complex<double>* cvec = reinterpret_cast<std::complex<double> *>(data_.data());
+        std::complex<int64_t>* cvec = reinterpret_cast<std::complex<int64_t> *>(data_.data());
         // calculate 3 components of variance
         for(size_t ct=0; ct < data_.size()/2; ct++) {
             buf[3*ct] = static_cast<double>(data2_[3*ct] - cvec[ct].real()*cvec[ct].real()/N) / scale;

--- a/src/X6_1000.cpp
+++ b/src/X6_1000.cpp
@@ -499,8 +499,40 @@ X6_1000::ErrorCodes X6_1000::transfer_variance(unsigned a, unsigned b, unsigned 
         return INVALID_CHANNEL;
     }
     //Don't copy more than we have
-    if (length < accumulators_[sid].data_.size() ) FILE_LOG(logERROR) << "Not enough memory allocated in buffer to transfer variance.";
+    if (length < accumulators_[sid].get_buffer_size() ) FILE_LOG(logERROR) << "Not enough memory allocated in buffer to transfer variance.";
     accumulators_[sid].snapshot_variance(buffer);
+    return SUCCESS;
+}
+
+X6_1000::ErrorCodes X6_1000::transfer_correlation(vector<Channel> & channels, double *buffer, size_t length) {
+    // check that we have the correlator
+    vector<uint16_t> sids(channels.size());
+    for (int i = 0; i < channels.size(); i++)
+        sids[i] = channels[i].streamID;
+    if (correlators_.find(sids) == correlators_.end()) {
+        FILE_LOG(logERROR) << "Tried to transfer invalid correlator.";
+        return INVALID_CHANNEL;
+    }
+    // Don't copy more than we have
+    if (length < correlators_[sids].get_buffer_size())
+        FILE_LOG(logERROR) << "Not enough memory allocated in buffer to transfer correlator.";
+    correlators_[sids].snapshot(buffer);
+    return SUCCESS;
+}
+
+X6_1000::ErrorCodes X6_1000::transfer_correlation_variance(vector<Channel> & channels, double *buffer, size_t length) {
+    // check that we have the correlator
+    vector<uint16_t> sids(channels.size());
+    for (int i = 0; i < channels.size(); i++)
+        sids[i] = channels[i].streamID;
+    if (correlators_.find(sids) == correlators_.end()) {
+        FILE_LOG(logERROR) << "Tried to transfer invalid correlator.";
+        return INVALID_CHANNEL;
+    }
+    // Don't copy more than we have
+    if (length < correlators_[sids].get_buffer_size())
+        FILE_LOG(logERROR) << "Not enough memory allocated in buffer to transfer correlator.";
+    correlators_[sids].snapshot_variance(buffer);
     return SUCCESS;
 }
 

--- a/src/X6_1000.cpp
+++ b/src/X6_1000.cpp
@@ -872,7 +872,7 @@ void Correlator::reset() {
     data_.assign(recordLength_*numSegments_, 0);
     idx_ = data_.begin();
     data2_.assign(recordLength_*numSegments_, 0);
-    idx2_ = data_.begin();
+    idx2_ = data2_.begin();
     wfmCt_ = 0;
     recordsTaken = 0;
 }

--- a/src/X6_1000.cpp
+++ b/src/X6_1000.cpp
@@ -486,7 +486,7 @@ X6_1000::ErrorCodes X6_1000::transfer_waveform(unsigned a, unsigned b, unsigned 
         return INVALID_CHANNEL;
     }
     //Don't copy more than we have
-    if (length < accumulators_[sid].data_.size() ) FILE_LOG(logERROR) << "Not enough memory allocated in buffer to transfer waveform.";
+    if (length < accumulators_[sid].get_buffer_size() ) FILE_LOG(logERROR) << "Not enough memory allocated in buffer to transfer waveform.";
     accumulators_[sid].snapshot(buffer);
     return SUCCESS;
 }
@@ -996,6 +996,10 @@ Channel::Channel(unsigned a, unsigned b, unsigned c) : channelID{a,b,c} {
 };
 
 vector<vector<int>> combinations(int n, int r) {
+    /*
+     * Returns all combinations of r choices from the list of integers 0,1,...,n-1.
+     * Based upon code in the Julia standard library.
+     */
     vector<vector<int>> c;
     vector<int> s(r);
     int i;

--- a/src/X6_1000.cpp
+++ b/src/X6_1000.cpp
@@ -677,7 +677,7 @@ void X6_1000::VMPDataAvailable(Innovative::VeloMergeParserDataAvailable & Event,
             if (accumulators_[sid].recordsTaken < numRecords_) {
                 accumulators_[sid].accumulate(ibufferDG);
                 // correlate with other result channels
-                for (auto kv : correlators_) {
+                for (auto & kv : correlators_) {
                     if (std::find(kv.first.begin(), kv.first.end(), sid) != kv.first.end()) {
                         kv.second.accumulate(sid, ibufferDG);
                     }
@@ -851,6 +851,10 @@ void Accumulator::snapshot_variance(double * buf) {
         for(size_t ct=0; ct < data2_.size(); ct++){
             buf[ct] = 0.0;
         }
+    } else if (channel_.type == PHYSICAL) {
+        for (size_t ct = 0; ct < data2_.size(); ct++) {
+            buf[ct] = static_cast<double>(data2_[ct] - data_[ct]*data_[ct]/N) / scale;
+        }
     } else {
         // construct complex vector of data
         std::complex<int64_t>* cvec = reinterpret_cast<std::complex<int64_t> *>(data_.data());
@@ -1000,7 +1004,7 @@ size_t Correlator::get_variance_buffer_size() {
 
 void Correlator::snapshot(double * buf) {
     /* Copies current data into a *preallocated* buffer*/
-    double N = max(static_cast<int>(recordsTaken), 1) / numSegments_;
+    double N = max(static_cast<int>(recordsTaken / numSegments_), 1);
     for(size_t ct=0; ct < data_.size(); ct++){
         buf[ct] = data_[ct] / N;
     }

--- a/src/X6_1000.h
+++ b/src/X6_1000.h
@@ -316,11 +316,11 @@ private:
 	map<uint16_t, int> bufferSID_;
 
 	// buffer for the correlated values A*B(*C*D*...)
-	vector<int64_t> data_;
-	vector<int64_t>::iterator idx_;
+	vector<double> data_;
+	vector<double>::iterator idx_;
 	// buffer for (A*B)^2
-	vector<__int128> data2_;
-	vector<__int128>::iterator idx2_;	
+	vector<double> data2_;
+	vector<double>::iterator idx2_;	
 };
 
 vector<vector<int>> combinations(int, int);

--- a/src/X6_1000.h
+++ b/src/X6_1000.h
@@ -145,11 +145,12 @@ public:
 	bool       get_is_running();
 	bool       get_has_new_data();
 
-	ErrorCodes transfer_waveform(unsigned, unsigned, unsigned, double *, size_t);
-	ErrorCodes transfer_variance(unsigned, unsigned, unsigned, double *, size_t);
+	ErrorCodes transfer_waveform(Channel, double *, size_t);
+	ErrorCodes transfer_variance(Channel, double *, size_t);
 	ErrorCodes transfer_correlation(vector<Channel> &, double *, size_t);
 	ErrorCodes transfer_correlation_variance(vector<Channel> &, double *, size_t);
-	int get_buffer_size(unsigned, unsigned, unsigned);
+	int get_buffer_size(vector<Channel> &);
+	int get_variance_buffer_size(vector<Channel> &);
 
 	ErrorCodes write_wishbone_register(uint32_t, uint32_t, uint32_t);
 	uint32_t read_wishbone_register(uint32_t, uint32_t) const;
@@ -269,6 +270,7 @@ public:
 	void snapshot(double *);
 	void snapshot_variance(double *);
 	size_t get_buffer_size();
+	size_t get_variance_buffer_size();
 	size_t calc_record_length(const Channel &, const size_t &);
 	int fixed_to_float(const Channel &);
 
@@ -301,6 +303,7 @@ public:
 	void snapshot(double *);
 	void snapshot_variance(double *);
 	size_t get_buffer_size();
+	size_t get_variance_buffer_size();
 
 	size_t recordsTaken;
 

--- a/src/X6_1000.h
+++ b/src/X6_1000.h
@@ -204,6 +204,7 @@ private:
 	void log_card_info();
 	bool check_done();
 
+	void initialize_accumulators();
 	void initialize_correlators();
 
 	void setHandler(OpenWire::EventHandler<OpenWire::NotifyEvent> &event, 
@@ -265,7 +266,6 @@ public:
 	template <class T>
 	void accumulate(const Innovative::AccessDatagram<T> &);
 
-	void init(const Channel &, const size_t &, const size_t &, const size_t &);
 	void reset();
 	void snapshot(double *);
 	void snapshot_variance(double *);

--- a/src/X6_1000.h
+++ b/src/X6_1000.h
@@ -25,6 +25,7 @@ using std::string;
  */
 
 class Accumulator;
+class Correlator;
 class Channel;
 
 enum channel_t { PHYSICAL, DEMOD, RESULT };
@@ -181,7 +182,7 @@ private:
 	vector<int> resultChans_;
 	//Some auxiliary accumlator data
 	map<uint16_t, Accumulator> accumulators_;
-	map<std::pair<uint16_t, uint16_t>, Correlator> correlators_;
+	map<vector<uint16_t>, Correlator> correlators_;
 
 	// State Variables
 	bool isOpen_;				  /**< cached flag indicaing board was openned */
@@ -278,7 +279,7 @@ private:
 class Correlator {
 public:
 	Correlator();
-	Correlator(const Channel &, const Channel &, const size_t &, const size_t &);
+	Correlator(const vector<Channel> &, const size_t &, const size_t &);
 	template <class T>
 	void correlate(const int &, const Innovative::AccessDatagram<T> &);
 
@@ -287,19 +288,18 @@ public:
 	void snapshot_variance(double *);
 	size_t get_buffer_size();
 
-	size_t recordLength;
 private:
 	size_t wfmCt_;
 	size_t numSegments_;
 	size_t numWaveforms_;
+	size_t recordLength_;
+	int fixed_to_float_;
 
-	// buffers for raw data from the two channels
-	vector<int> bufA;
-	vector<int> bufB;
-	int sidA;
-	int sidB;
+	// buffers for raw data from the channels
+	vector<vector<int>> buffers_;
+	vector<int> SIDs_;
 
-	// buffer for the correlated values A*B
+	// buffer for the correlated values A*B(*C*D*...)
 	vector<int64_t> data_;
 	vector<int64_t>::iterator idx_;
 	// buffer for (A*B)^2
@@ -316,6 +316,8 @@ public:
 	uint16_t streamID;
 	channel_t type;
 };
+
+vector<vector<int>> combinations(int, int);
 
 
 #endif

--- a/src/X6_1000.h
+++ b/src/X6_1000.h
@@ -181,6 +181,7 @@ private:
 	vector<int> resultChans_;
 	//Some auxiliary accumlator data
 	map<uint16_t, Accumulator> accumulators_;
+	map<std::pair<uint16_t, uint16_t>, Correlator> correlators_;
 
 	// State Variables
 	bool isOpen_;				  /**< cached flag indicaing board was openned */
@@ -198,6 +199,8 @@ private:
 	void set_defaults();
 	void log_card_info();
 	bool check_done();
+
+	void initialize_correlators();
 
 	void setHandler(OpenWire::EventHandler<OpenWire::NotifyEvent> &event, 
     				void (X6_1000:: *CallBackFunction)(OpenWire::NotifyEvent & Event));
@@ -279,7 +282,6 @@ public:
 	template <class T>
 	void correlate(const int &, const Innovative::AccessDatagram<T> &);
 
-	void init(const Channel &, const Channel &, const size_t &, const size_t &);
 	void reset();
 	void snapshot(double *);
 	void snapshot_variance(double *);
@@ -294,6 +296,8 @@ private:
 	// buffers for raw data from the two channels
 	vector<int> bufA;
 	vector<int> bufB;
+	int sidA;
+	int sidB;
 
 	// buffer for the correlated values A*B
 	vector<int64_t> data_;

--- a/src/X6_1000.h
+++ b/src/X6_1000.h
@@ -272,6 +272,37 @@ private:
 	vector<int64_t>::iterator idx2_;
 };
 
+class Correlator {
+public:
+	Correlator();
+	Correlator(const Channel &, const Channel &, const size_t &, const size_t &);
+	template <class T>
+	void correlate(const int &, const Innovative::AccessDatagram<T> &);
+
+	void init(const Channel &, const Channel &, const size_t &, const size_t &);
+	void reset();
+	void snapshot(double *);
+	void snapshot_variance(double *);
+	size_t get_buffer_size();
+
+	size_t recordLength;
+private:
+	size_t wfmCt_;
+	size_t numSegments_;
+	size_t numWaveforms_;
+
+	// buffers for raw data from the two channels
+	vector<int> bufA;
+	vector<int> bufB;
+
+	// buffer for the correlated values A*B
+	vector<int64_t> data_;
+	vector<int64_t>::iterator idx_;
+	// buffer for (A*B)^2
+	vector<int64_t> data2_;
+	vector<int64_t>::iterator idx2_;	
+};
+
 class Channel{
 public:
 	Channel();

--- a/src/X6_1000.h
+++ b/src/X6_1000.h
@@ -265,6 +265,7 @@ public:
 	size_t recordsTaken;
 
 private:
+	Channel channel_:
 	size_t wfmCt_;
 	size_t numSegments_;
 	size_t numWaveforms_;

--- a/src/X6_1000.h
+++ b/src/X6_1000.h
@@ -244,6 +244,16 @@ private:
     void LogHandler(string handlerName);
 };
 
+class Channel{
+public:
+	Channel();
+	Channel(unsigned, unsigned, unsigned);
+
+	unsigned channelID[3];
+	uint16_t streamID;
+	channel_t type;
+};
+
 class Accumulator{
 friend X6_1000;
 
@@ -265,7 +275,7 @@ public:
 	size_t recordsTaken;
 
 private:
-	Channel channel_:
+	Channel channel_;
 	size_t wfmCt_;
 	size_t numSegments_;
 	size_t numWaveforms_;
@@ -311,16 +321,6 @@ private:
 	// buffer for (A*B)^2
 	vector<__int128> data2_;
 	vector<__int128>::iterator idx2_;	
-};
-
-class Channel{
-public:
-	Channel();
-	Channel(unsigned, unsigned, unsigned);
-
-	unsigned channelID[3];
-	uint16_t streamID;
-	channel_t type;
 };
 
 vector<vector<int>> combinations(int, int);

--- a/src/X6_1000.h
+++ b/src/X6_1000.h
@@ -306,8 +306,8 @@ private:
 	vector<int64_t> data_;
 	vector<int64_t>::iterator idx_;
 	// buffer for (A*B)^2
-	vector<int64_t> data2_;
-	vector<int64_t>::iterator idx2_;	
+	vector<__int128> data2_;
+	vector<__int128>::iterator idx2_;	
 };
 
 class Channel{

--- a/src/X6_1000.h
+++ b/src/X6_1000.h
@@ -147,6 +147,8 @@ public:
 
 	ErrorCodes transfer_waveform(unsigned, unsigned, unsigned, double *, size_t);
 	ErrorCodes transfer_variance(unsigned, unsigned, unsigned, double *, size_t);
+	ErrorCodes transfer_correlation(vector<Channel> &, double *, size_t);
+	ErrorCodes transfer_correlation_variance(vector<Channel> &, double *, size_t);
 	int get_buffer_size(unsigned, unsigned, unsigned);
 
 	ErrorCodes write_wishbone_register(uint32_t, uint32_t, uint32_t);

--- a/src/X6_1000.h
+++ b/src/X6_1000.h
@@ -281,23 +281,26 @@ public:
 	Correlator();
 	Correlator(const vector<Channel> &, const size_t &, const size_t &);
 	template <class T>
-	void correlate(const int &, const Innovative::AccessDatagram<T> &);
+	void accumulate(const int &, const Innovative::AccessDatagram<T> &);
+	void correlate();
 
 	void reset();
 	void snapshot(double *);
 	void snapshot_variance(double *);
 	size_t get_buffer_size();
 
+	size_t recordsTaken;
+
 private:
 	size_t wfmCt_;
 	size_t numSegments_;
 	size_t numWaveforms_;
 	size_t recordLength_;
-	int fixed_to_float_;
+	int64_t fixed_to_float_;
 
 	// buffers for raw data from the channels
 	vector<vector<int>> buffers_;
-	vector<int> SIDs_;
+	map<uint16_t, int> bufferSID_;
 
 	// buffer for the correlated values A*B(*C*D*...)
 	vector<int64_t> data_;

--- a/src/constants.h
+++ b/src/constants.h
@@ -39,5 +39,7 @@ typedef enum {DIGITIZE=0, AVERGAGE, FILTER, FILTER_AND_AVERAGE} DIGITIZER_MODE;
 static const int VIRTUAL_CH_RATIO = 2; // Number of virtual channels per physical channel
 static const int DECIMATION_FACTOR = 16;
 
+// Correlations
+static const int MAX_N_BODY_CORRELATIONS = 3;
 
 #endif /* CONSTANTS_H_ */

--- a/src/libx6adc.cpp
+++ b/src/libx6adc.cpp
@@ -153,37 +153,50 @@ int stop(int deviceID) {
 	return X6s_[deviceID]->stop();
 }
 
-int transfer_waveform(int deviceID, unsigned a, unsigned b, unsigned c, double *buffer, unsigned bufferLength) {
-	if (!is_open(deviceID)) return X6_1000::DEVICE_NOT_CONNECTED;
-	return X6s_[deviceID]->transfer_waveform(a, b, c, buffer, bufferLength);
-}
-
-int transfer_variance(int deviceID, unsigned a, unsigned b, unsigned c, double *buffer, unsigned bufferLength) {
-	if (!is_open(deviceID)) return X6_1000::DEVICE_NOT_CONNECTED;
-	return X6s_[deviceID]->transfer_variance(a, b, c, buffer, bufferLength);
-}
-
-int transfer_correlation(int deviceID, ChannelTuple *channelTuples, unsigned numChannels, double *buffer, unsigned bufferLength) {
+int transfer_waveform(int deviceID, ChannelTuple *channelTuples, unsigned numChannels, double *buffer, unsigned bufferLength) {
+	// when passed a single ChannelTuple, fills buffer with the corresponding waveform data
+	// when passed multple ChannelTuples, fills buffer with the corresponding correlation data
 	if (!is_open(deviceID)) return X6_1000::DEVICE_NOT_CONNECTED;
 	vector<Channel> channels(numChannels);
 	for (int i = 0; i < numChannels; i++) {
 		channels[i] = Channel(channelTuples[i].a, channelTuples[i].b, channelTuples[i].c);
 	}
-	return X6s_[deviceID]->transfer_correlation(channels, buffer, bufferLength);
+	if (numChannels == 1) {
+		return X6s_[deviceID]->transfer_waveform(channels[0], buffer, bufferLength);
+	} else {
+		return X6s_[deviceID]->transfer_correlation(channels, buffer, bufferLength);
+	}
 }
 
-int transfer_correlation_variance(int deviceID, ChannelTuple *channelTuples, unsigned numChannels, double *buffer, unsigned bufferLength) {
+int transfer_variance(int deviceID, ChannelTuple *channelTuples, unsigned numChannels, double *buffer, unsigned bufferLength) {
 	if (!is_open(deviceID)) return X6_1000::DEVICE_NOT_CONNECTED;
 	vector<Channel> channels(numChannels);
 	for (int i = 0; i < numChannels; i++) {
 		channels[i] = Channel(channelTuples[i].a, channelTuples[i].b, channelTuples[i].c);
 	}
-	return X6s_[deviceID]->transfer_correlation_variance(channels, buffer, bufferLength);
+	if (numChannels == 1) {
+		return X6s_[deviceID]->transfer_variance(channels[0], buffer, bufferLength);
+	} else {
+		return X6s_[deviceID]->transfer_correlation_variance(channels, buffer, bufferLength);
+	}
 }
 
-int get_buffer_size(int deviceID, unsigned a, unsigned b, unsigned c) {
+int get_buffer_size(int deviceID, ChannelTuple *channelTuples, unsigned numChannels) {
 	if (!is_open(deviceID)) return X6_1000::DEVICE_NOT_CONNECTED;
-	return X6s_[deviceID]->get_buffer_size(a, b, c);
+	vector<Channel> channels(numChannels);
+	for (int i = 0; i < numChannels; i++) {
+		channels[i] = Channel(channelTuples[i].a, channelTuples[i].b, channelTuples[i].c);
+	}
+	return X6s_[deviceID]->get_buffer_size(channels);
+}
+
+int get_variance_buffer_size(int deviceID, ChannelTuple *channelTuples, unsigned numChannels) {
+	if (!is_open(deviceID)) return X6_1000::DEVICE_NOT_CONNECTED;
+	vector<Channel> channels(numChannels);
+	for (int i = 0; i < numChannels; i++) {
+		channels[i] = Channel(channelTuples[i].a, channelTuples[i].b, channelTuples[i].c);
+	}
+	return X6s_[deviceID]->get_variance_buffer_size(channels);
 }
 
 //Expects a null-terminated character array

--- a/src/libx6adc.cpp
+++ b/src/libx6adc.cpp
@@ -163,6 +163,24 @@ int transfer_variance(int deviceID, unsigned a, unsigned b, unsigned c, double *
 	return X6s_[deviceID]->transfer_variance(a, b, c, buffer, bufferLength);
 }
 
+int transfer_correlation(int deviceID, ChannelTuple *channelTuples, unsigned numChannels, double *buffer, unsigned bufferLength) {
+	if (!is_open(deviceID)) return X6_1000::DEVICE_NOT_CONNECTED;
+	vector<Channel> channels(numChannels);
+	for (int i = 0; i < numChannels; i++) {
+		channels[i] = Channel(channelTuples[i].a, channelTuples[i].b, channelTuples[i].c);
+	}
+	return X6s_[deviceID]->transfer_correlation(channels, buffer, bufferLength);
+}
+
+int transfer_correlation_variance(int deviceID, ChannelTuple *channelTuples, unsigned numChannels, double *buffer, unsigned bufferLength) {
+	if (!is_open(deviceID)) return X6_1000::DEVICE_NOT_CONNECTED;
+	vector<Channel> channels(numChannels);
+	for (int i = 0; i < numChannels; i++) {
+		channels[i] = Channel(channelTuples[i].a, channelTuples[i].b, channelTuples[i].c);
+	}
+	return X6s_[deviceID]->transfer_correlation_variance(channels, buffer, bufferLength);
+}
+
 int get_buffer_size(int deviceID, unsigned a, unsigned b, unsigned c) {
 	if (!is_open(deviceID)) return X6_1000::DEVICE_NOT_CONNECTED;
 	return X6s_[deviceID]->get_buffer_size(a, b, c);

--- a/src/libx6adc.h
+++ b/src/libx6adc.h
@@ -70,11 +70,10 @@ EXPORT int wait_for_acquisition(int, int);
 EXPORT int get_is_running(int);
 EXPORT int get_has_new_data(int);
 EXPORT int stop(int);
-EXPORT int transfer_waveform(int, unsigned, unsigned, unsigned, double *, unsigned);
-EXPORT int transfer_variance(int, unsigned, unsigned, unsigned, double *, unsigned);
-EXPORT int transfer_correlation(int, ChannelTuple *, unsigned, double *, unsigned);
-EXPORT int transfer_correlation_variance(int, ChannelTuple *, unsigned, double *, unsigned);
-EXPORT int get_buffer_size(int, unsigned, unsigned, unsigned);
+EXPORT int transfer_waveform(int, ChannelTuple *, unsigned, double *, unsigned);
+EXPORT int transfer_variance(int, ChannelTuple *, unsigned, double *, unsigned);
+EXPORT int get_buffer_size(int, ChannelTuple *, unsigned);
+EXPORT int get_variance_buffer_size(int, ChannelTuple *, unsigned);
 
 EXPORT int set_log(char *);
 int update_log(FILE * pFile);

--- a/src/libx6adc.h
+++ b/src/libx6adc.h
@@ -31,6 +31,11 @@ enum X6ErrorCode {
 	X6_TIMEOUT = -7
 };
 
+struct ChannelTuple {
+	int a;
+	int b;
+	int c;
+};
 
 void init() __attribute__((constructor));
 void cleanup() __attribute__((destructor));
@@ -67,6 +72,8 @@ EXPORT int get_has_new_data(int);
 EXPORT int stop(int);
 EXPORT int transfer_waveform(int, unsigned, unsigned, unsigned, double *, unsigned);
 EXPORT int transfer_variance(int, unsigned, unsigned, unsigned, double *, unsigned);
+EXPORT int transfer_correlation(int, ChannelTuple *, unsigned, double *, unsigned);
+EXPORT int transfer_correlation_variance(int, ChannelTuple *, unsigned, double *, unsigned);
 EXPORT int get_buffer_size(int, unsigned, unsigned, unsigned);
 
 EXPORT int set_log(char *);

--- a/src/libx6adc.matlab.h
+++ b/src/libx6adc.matlab.h
@@ -31,6 +31,12 @@ enum X6ErrorCode {
 	X6_TIMEOUT = -7
 };
 
+struct ChannelTuple {
+	int a;
+	int b;
+	int c;
+};
+
 EXPORT int connect_by_ID(int);
 EXPORT int disconnect(int);
 EXPORT unsigned get_num_devices();
@@ -61,8 +67,10 @@ EXPORT int wait_for_acquisition(int, int);
 EXPORT int get_is_running(int);
 EXPORT int get_has_new_data(int);
 EXPORT int stop(int);
-EXPORT int transfer_waveform(int, unsigned, unsigned, unsigned, double *, unsigned);
-EXPORT int get_buffer_size(int, unsigned, unsigned, unsigned);
+EXPORT int transfer_waveform(int, ChannelTuple *, unsigned, double *, unsigned);
+EXPORT int transfer_variance(int, ChannelTuple *, unsigned, double *, unsigned);
+EXPORT int get_buffer_size(int, ChannelTuple *, unsigned);
+EXPORT int get_variance_buffer_size(int, ChannelTuple *, unsigned);
 
 EXPORT int set_log(char *);
 int update_log(FILE * pFile);

--- a/src/libx6adc.matlab.h
+++ b/src/libx6adc.matlab.h
@@ -67,10 +67,10 @@ EXPORT int wait_for_acquisition(int, int);
 EXPORT int get_is_running(int);
 EXPORT int get_has_new_data(int);
 EXPORT int stop(int);
-EXPORT int transfer_waveform(int, ChannelTuple *, unsigned, double *, unsigned);
-EXPORT int transfer_variance(int, ChannelTuple *, unsigned, double *, unsigned);
-EXPORT int get_buffer_size(int, ChannelTuple *, unsigned);
-EXPORT int get_variance_buffer_size(int, ChannelTuple *, unsigned);
+EXPORT int transfer_waveform(int, struct ChannelTuple *, unsigned, double *, unsigned);
+EXPORT int transfer_variance(int, struct ChannelTuple *, unsigned, double *, unsigned);
+EXPORT int get_buffer_size(int, struct ChannelTuple *, unsigned);
+EXPORT int get_variance_buffer_size(int, struct ChannelTuple *, unsigned);
 
 EXPORT int set_log(char *);
 int update_log(FILE * pFile);

--- a/test/X6.m
+++ b/test/X6.m
@@ -225,7 +225,7 @@ classdef X6 < hgsetget
             assert(success == 0, 'transfer_variance failed');
 
             wf = struct('real', [], 'imag', [], 'prod', []);
-            if b == 0 % physical channel
+            if channels(1).b == 0 % physical channel
                 wf.real = wfPtr.Value;
                 wf.imag = zeros(length(wfPtr.Value), 1);
                 wf.prod = zeros(length(wfPtr.Value), 1);
@@ -234,7 +234,7 @@ classdef X6 < hgsetget
                 wf.imag = wfPtr.Value(1:3:end);
                 wf.prod = wfPtr.Value(3:3:end);
             end
-            if c == 0 % non-results streams should be reshaped
+            if channels(1).c == 0 % non-results streams should be reshaped
                 wf.real = reshape(wf.real, length(wf.real)/obj.nbrSegments, obj.nbrSegments);
                 wf.imag = reshape(wf.imag, length(wf.imag)/obj.nbrSegments, obj.nbrSegments);
                 wf.prod = reshape(wf.prod, length(wf.prod)/obj.nbrSegments, obj.nbrSegments);

--- a/test/X6.m
+++ b/test/X6.m
@@ -419,16 +419,16 @@ classdef X6 < hgsetget
             x6.set_nco_frequency(2, 2, 40e6);
             
             fprintf('Writing integration kernels\n');
-            x6.write_kernel(1, 1, ones(128,1));
-            x6.write_kernel(1, 2, ones(128,1));
-            x6.write_kernel(2, 1, ones(128,1));
-            x6.write_kernel(2, 2, ones(128,1));
+            x6.write_kernel(1, 1, ones(100,1));
+            x6.write_kernel(1, 2, ones(100,1));
+            x6.write_kernel(2, 1, ones(100,1));
+            x6.write_kernel(2, 2, ones(100,1));
             
             fprintf('Writing decision engine thresholds\n');
-            x6.set_threshold(1, 1, 4000);
-            x6.set_threshold(1, 2, 4000);
-            x6.set_threshold(2, 1, 4000);
-            x6.set_threshold(2, 2, 4000);
+            x6.set_threshold(1, 1, 0.5);
+            x6.set_threshold(1, 2, 0.5);
+            x6.set_threshold(2, 1, 0.5);
+            x6.set_threshold(2, 2, 0.5);
             
             fprintf('setting averager parameters to record 9 segments of 2048 samples\n');
             x6.set_averager_settings(2048, 9, 1, 1);
@@ -436,7 +436,7 @@ classdef X6 < hgsetget
             fprintf('Acquiring\n');
             x6.acquire();
 
-            success = x6.wait_for_acquisition(0.1);
+            success = x6.wait_for_acquisition(1);
             fprintf('Wait for acquisition returned %d\n', success);
 
             fprintf('Stopping\n');
@@ -477,6 +477,12 @@ classdef X6 < hgsetget
                 plot(imag(wfs{ct+1}(:)), 'r');
                 title(sprintf('Virtual Channel %d',ct));
             end
+
+            fprintf('Result vectors:\n');
+            fprintf('Ch 1.1:\n'); disp(real(x6.transfer_stream(struct('a', 1, 'b', 1, 'c', 1))));
+            fprintf('Ch 1.2:\n'); disp(real(x6.transfer_stream(struct('a', 1, 'b', 2, 'c', 1))));
+            fprintf('Ch 2.1:\n'); disp(real(x6.transfer_stream(struct('a', 2, 'b', 1, 'c', 1))));
+            fprintf('Ch 2.2:\n'); disp(real(x6.transfer_stream(struct('a', 2, 'b', 2, 'c', 1))));
 
             x6.disconnect();
             unloadlibrary('libx6adc')

--- a/test/X6.m
+++ b/test/X6.m
@@ -210,6 +210,44 @@ classdef X6 < hgsetget
                 wf = reshape(wf, length(wf)/obj.nbrSegments, obj.nbrSegments);
             end
         end
+
+        function wf = transfer_stream_variance(obj, a, b, c)
+            bufSize = obj.libraryCall('get_buffer_size', a, b, c);
+            wfPtr = libpointer('doublePtr', zeros(bufSize, 1, 'double'));
+            success = obj.libraryCall('transfer_variance', a, b, c, wfPtr, bufSize);
+            assert(success == 0, 'transfer_variance failed');
+
+            if b == 0 % physical channel
+                wf = wfPtr.Value;
+            else
+                wf = wfPtr.Value(1:2:end) +1i*wfPtr.Value(2:2:end);
+            end
+            if c == 0 % non-results streams should be reshaped
+                wf = reshape(wf, length(wf)/obj.nbrSegments, obj.nbrSegments);
+            end
+        end
+
+        function wf = transfer_correlation(obj, channels)
+            % expects channels to be a vector of structs of the form:
+            % struct('a', X, 'b', Y, 'c', Z)
+            bufSize = obj.libraryCall('get_buffer_size', channels(1).a, channels(1).b, channels(2).c);
+            wfPtr = libpointer('doublePtr', zeros(bufSize, 1, 'double'));
+            success = obj.libraryCall('transfer_correlation', channels, length(channels), wfPtr, bufSize);
+            assert(success == 0, 'transfer_correlation failed');
+
+            wf = wfPtr.Value(1:2:end) + 1i*wfPtr.Value(2:2:end);
+        end
+
+        function wf = transfer_correlation_variance(obj, channels)
+            % expects channels to be a vector of structs of the form:
+            % struct('a', X, 'b', Y, 'c', Z)
+            bufSize = obj.libraryCall('get_buffer_size', channels(1).a, channels(1).b, channels(2).c);
+            wfPtr = libpointer('doublePtr', zeros(bufSize, 1, 'double'));
+            success = obj.libraryCall('transfer_correlation_variance', channels, length(channels), wfPtr, bufSize);
+            assert(success == 0, 'transfer_correlation failed');
+
+            wf = wfPtr.Value(1:2:end) + 1i*wfPtr.Value(2:2:end);
+        end
         
         function val = writeRegister(obj, addr, offset, data)
             % get temprature using method one based on Malibu Objects

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -90,7 +90,9 @@ int main ()
 
   cout << "Transferring waveform ch1" << endl;
   vector<double> buffer(10240);
-  transfer_waveform(0, 1, 0, 0, buffer.data(), 10240);
+  ChannelTuple rawch = {1, 0, 0};
+  ChannelTuple channels[1] = {rawch};
+  transfer_waveform(0, channels, 1, buffer.data(), 10240);
 
   cout << "Stopping" << endl;
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -86,7 +86,7 @@ int main ()
 
   cout << "setting averager parameters to record 10 segments of 1024 samples" << endl;
 
-  set_averager_settings(0, 2048, 9, 1, 1);
+  set_averager_settings(0, 2048, 9, 1, 2);
 
   cout << "Acquiring" << endl;
 
@@ -102,14 +102,21 @@ int main ()
     cout << "Unknown error in wait_for_acquisition" << endl;
   }
 
-
   cout << "Transferring waveform ch1" << endl;
   vector<double> buffer;
-  ChannelTuple rawch = {1, 0, 0};
-  ChannelTuple channels[1] = {rawch};
+  ChannelTuple channels[1] = {{1,0,0}};
   int bufsize = get_buffer_size(0, channels, 1);
   buffer.resize(bufsize);
   transfer_waveform(0, channels, 1, buffer.data(), buffer.size());
+
+  cout << "Transferring variance raw ch1" << endl;
+  transfer_variance(0, channels, 1, buffer.data(), buffer.size());
+
+  cout << "Transfer correlation" << endl;
+  ChannelTuple channels2[2] = {{1,1,1}, {2,1,1}};
+  bufsize = get_buffer_size(0, channels2, 2);
+  buffer.resize(bufsize);
+  transfer_waveform(0, channels2, 2, buffer.data(), buffer.size());
 
   cout << "Stopping" << endl;
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -18,7 +18,7 @@ int main ()
 {
   cout << "BBN X6-1000 Test Executable" << endl;
 
-  set_logging_level(5);
+  set_logging_level(8);
 
   int numDevices;
   numDevices = get_num_devices();
@@ -48,17 +48,17 @@ int main ()
 
   cout << "current PLL frequency = " << get_sampleRate(0)/1e6 << " MHz" << endl;
 
-  cout << "Set sample rate to 100 MHz" << endl;
+  // cout << "Set sample rate to 100 MHz" << endl;
 
-  set_sampleRate(0,100e6);
+  // set_sampleRate(0,100e6);
 
-  cout << "current PLL frequency = " << get_sampleRate(0)/1e6 << " MHz" << endl;
+  // cout << "current PLL frequency = " << get_sampleRate(0)/1e6 << " MHz" << endl;
 
-  cout << "Set sample rate back to 1000 MHz" << endl;
+  // cout << "Set sample rate back to 1000 MHz" << endl;
 
-  set_sampleRate(0,1e9);
+  // set_sampleRate(0,1e9);
 
-  cout << "current PLL frequency = " << get_sampleRate(0)/1e6 << " MHz" << endl;
+  // cout << "current PLL frequency = " << get_sampleRate(0)/1e6 << " MHz" << endl;
 
   cout << "setting trigger source = EXTERNAL_TRIGGER" << endl;
 
@@ -68,17 +68,32 @@ int main ()
 
   cout << "Enabling physical channel 1" << endl;
   enable_stream(0, 1, 0, 0);
+  enable_stream(0, 1, 1, 0);
+  enable_stream(0, 1, 1, 1);
+  enable_stream(0, 1, 2, 0);
+  enable_stream(0, 1, 2, 1);
+  enable_stream(0, 2, 0, 0);
+  enable_stream(0, 2, 1, 0);
+  enable_stream(0, 2, 1, 1);
+  enable_stream(0, 2, 2, 0);
+  enable_stream(0, 2, 2, 1);
+
+  cout << "Writing kernel lengths" << endl;
+  write_register(0, 0x2000, 24+1-1, 2);
+  write_register(0, 0x2000, 24+2-1, 2);
+  write_register(0, 0x2100, 24+1-1, 2);
+  write_register(0, 0x2100, 24+2-1, 2);
 
   cout << "setting averager parameters to record 10 segments of 1024 samples" << endl;
 
-  set_averager_settings(0, 1024, 10, 1, 1);
+  set_averager_settings(0, 2048, 9, 1, 1);
 
   cout << "Acquiring" << endl;
 
   acquire(0);
 
   cout << "Waiting for acquisition to complete" << endl;
-  int success = wait_for_acquisition(0, 1);
+  int success = wait_for_acquisition(0, 2);
   if (success == X6_OK) {
     cout << "Acquistion finished" << endl;
   } else if (success == X6_1000::TIMEOUT) {
@@ -89,10 +104,12 @@ int main ()
 
 
   cout << "Transferring waveform ch1" << endl;
-  vector<double> buffer(10240);
+  vector<double> buffer;
   ChannelTuple rawch = {1, 0, 0};
   ChannelTuple channels[1] = {rawch};
-  transfer_waveform(0, channels, 1, buffer.data(), 10240);
+  int bufsize = get_buffer_size(0, channels, 1);
+  buffer.resize(bufsize);
+  transfer_waveform(0, channels, 1, buffer.data(), buffer.size());
 
   cout << "Stopping" << endl;
 

--- a/test/unit.cpp
+++ b/test/unit.cpp
@@ -112,8 +112,8 @@ int main ()
 
   // Correlators
   Channel ch1(1,1,1), ch2(1,2,1);
-  int sid1 = 273;
-  int sid2 = 289;
+  int sid1 = ch1.streamID;
+  int sid2 = ch2.streamID;
   Correlator correlator({ch1, ch2}, 2, 1);
 
   ibuf[0] = 0 * scale; ibuf[1] = 10 * scale; // segment 1, ch1
@@ -132,9 +132,24 @@ int main ()
   cout << "obuf[2]: " << obuf[2] << endl;
   cout << "obuf[3]: " << obuf[3] << endl;
   assert(obuf[0] == 0);
-  assert(obuf[1] == 200);
-  assert(obuf[2] == 6);
-  assert(obuf[3] == 20000);
+  assert(obuf[1] == 10*20);
+  assert(obuf[2] == 2*3);
+  assert(obuf[3] == 100*200);
+
+  Channel ch3(2,1,1);
+  int sid3 = ch3.streamID;
+  Correlator correlator2({ch1, ch2, ch3}, 1, 1);
+
+  ibuf[0] = 0 * scale; ibuf[1] = 10 * scale; // segment 1, ch1
+  correlator2.accumulate(sid1, ibuf);
+  ibuf[0] = 1 * scale; ibuf[1] = 20 * scale; // segment 1, ch2
+  correlator2.accumulate(sid2, ibuf);
+  ibuf[0] = 3 * scale; ibuf[1] = 30 * scale; // segment 1, ch2
+  correlator2.accumulate(sid3, ibuf);
+
+  correlator2.snapshot(obuf);
+  assert(obuf[0] == 0);
+  assert(obuf[1] == 10*20*30);
 
   return 0;
 }

--- a/test/unit.cpp
+++ b/test/unit.cpp
@@ -173,11 +173,11 @@ int main ()
   cout << "obufvar[3]: " << obufvar[3] << " (goal 128)" << endl;
   cout << "obufvar[4]: " << obufvar[4] << " (goal 1568)" << endl;
   cout << "obufvar[5]: " << obufvar[5] << " (goal -448)" << endl;
-  assert(obufvar[0] == 128);
-  assert(obufvar[1] == 1568);
+  assert(obufvar[0] == 1568);
+  assert(obufvar[1] == 128);
   assert(obufvar[2] == 448);
-  assert(obufvar[3] == 128);
-  assert(obufvar[4] == 1568);
+  assert(obufvar[3] == 1568);
+  assert(obufvar[4] == 128);
   assert(obufvar[5] == -448);
 
   Channel ch3(2,1,1);

--- a/test/unit.cpp
+++ b/test/unit.cpp
@@ -131,10 +131,21 @@ int main ()
   cout << "obuf[1]: " << obuf[1] << endl;
   cout << "obuf[2]: " << obuf[2] << endl;
   cout << "obuf[3]: " << obuf[3] << endl;
-  assert(obuf[0] == 0);
-  assert(obuf[1] == 10*20);
-  assert(obuf[2] == 2*3);
-  assert(obuf[3] == 100*200);
+  assert(obuf[0] == 0*1 - 10*20);
+  assert(obuf[1] == 0*20 + 1*10);
+  assert(obuf[2] == 2*3 - 100*200);
+  assert(obuf[3] == 2*200 + 3*100);
+
+  correlator.snapshot_variance(obuf);
+  cout << "snapshot variance: " << endl;
+  cout << "obuf[0]: " << obuf[0] << endl;
+  cout << "obuf[1]: " << obuf[1] << endl;
+  cout << "obuf[2]: " << obuf[2] << endl;
+  cout << "obuf[3]: " << obuf[3] << endl;
+  assert(obuf[0] == 50.5);
+  assert(obuf[1] == 0);
+  assert(obuf[2] == 5000.5);
+  assert(obuf[3] == 0);
 
   Channel ch3(2,1,1);
   int sid3 = ch3.streamID;
@@ -144,12 +155,15 @@ int main ()
   correlator2.accumulate(sid1, ibuf);
   ibuf[0] = 1 * scale; ibuf[1] = 20 * scale; // segment 1, ch2
   correlator2.accumulate(sid2, ibuf);
-  ibuf[0] = 3 * scale; ibuf[1] = 30 * scale; // segment 1, ch2
+  ibuf[0] = 2 * scale; ibuf[1] = 30 * scale; // segment 1, ch2
   correlator2.accumulate(sid3, ibuf);
 
   correlator2.snapshot(obuf);
-  assert(obuf[0] == 0);
-  assert(obuf[1] == 10*20*30);
+  cout << "snapshot correlator: " << endl;
+  cout << "obuf[0]: " << obuf[0] << endl;
+  cout << "obuf[1]: " << obuf[1] << endl;
+  assert(obuf[0] == 0*1*2 - 0*20*30 - 10*1*30 - 10*20*2);
+  assert(obuf[1] == -10*20*30 + 10*1*2 + 0*20*2 + 0*1*30);
 
   return 0;
 }

--- a/test/unit.cpp
+++ b/test/unit.cpp
@@ -48,12 +48,21 @@ int main ()
   assert(obuf[2] == 2);
   assert(obuf[3] == 150);
 
-  double obufvar[4];
+  double obufvar[6];
   accumlator.snapshot_variance(obufvar);
+  cout << "snapshot variance: " << endl;
+  cout << "obufvar[0]: " << obufvar[0] << " (goal 2)" << endl;
+  cout << "obufvar[1]: " << obufvar[1] << " (goal 50)" << endl;
+  cout << "obufvar[2]: " << obufvar[2] << " (goal 10)" << endl;
+  cout << "obufvar[3]: " << obufvar[3] << " (goal 2)" << endl;
+  cout << "obufvar[4]: " << obufvar[4] << " (goal 5000)" << endl;
+  cout << "obufvar[5]: " << obufvar[5] << " (goal 100)" << endl;
   assert(obufvar[0] == 2);
   assert(obufvar[1] == 50);
-  assert(obufvar[2] == 2);
-  assert(obufvar[3] == 5000);
+  assert(obufvar[2] == 10);
+  assert(obufvar[3] == 2);
+  assert(obufvar[4] == 5000);
+  assert(obufvar[5] == 100);
 
   ibuf[0] = 4 * scale; ibuf[1] = 30 * scale; // segment 1
   accumlator.accumulate(ibuf);
@@ -67,16 +76,19 @@ int main ()
   assert(obuf[3] == 200);
 
   accumlator.snapshot_variance(obufvar);
-  assert(obufvar[0] == 4);
-  assert(obufvar[1] == 100);
-  assert(obufvar[2] == 4);
-  assert(obufvar[3] == 10000);
-
   cout << "snapshot variance: " << endl;
   cout << "obufvar[0]: " << obufvar[0] << " (goal 4)" << endl;
   cout << "obufvar[1]: " << obufvar[1] << " (goal 100)" << endl;
-  cout << "obufvar[2]: " << obufvar[2] << " (goal 4)" << endl;
-  cout << "obufvar[3]: " << obufvar[3] << " (goal 10000)" << endl;
+  cout << "obufvar[2]: " << obufvar[2] << " (goal 20)" << endl;
+  cout << "obufvar[3]: " << obufvar[3] << " (goal 4)" << endl;
+  cout << "obufvar[4]: " << obufvar[4] << " (goal 10000)" << endl;
+  cout << "obufvar[5]: " << obufvar[5] << " (goal 200)" << endl;
+  assert(obufvar[0] == 4);
+  assert(obufvar[1] == 100);
+  assert(obufvar[2] == 20);
+  assert(obufvar[3] == 4);
+  assert(obufvar[4] == 10000);
+  assert(obufvar[5] == 200);
 
   // Combinations test
   vector<vector<int>> combos;
@@ -116,13 +128,13 @@ int main ()
   int sid2 = ch2.streamID;
   Correlator correlator({ch1, ch2}, 2, 1);
 
-  ibuf[0] = 0 * scale; ibuf[1] = 10 * scale; // segment 1, ch1
+  ibuf[0] = 0 * scale; ibuf[1] = 7 * scale; // segment 1, ch1
   correlator.accumulate(sid1, ibuf);
-  ibuf[0] = 1 * scale; ibuf[1] = 20 * scale; // segment 1, ch2
+  ibuf[0] = 1 * scale; ibuf[1] = 6 * scale; // segment 1, ch2
   correlator.accumulate(sid2, ibuf);
-  ibuf[0] = 2 * scale; ibuf[1] = 100 * scale; // segment 2, ch1
+  ibuf[0] = 2 * scale; ibuf[1] = 5 * scale; // segment 2, ch1
   correlator.accumulate(sid1, ibuf);
-  ibuf[0] = 3 * scale; ibuf[1] = 200 * scale; // segment 2, ch2
+  ibuf[0] = 3 * scale; ibuf[1] = 4 * scale; // segment 2, ch2
   correlator.accumulate(sid2, ibuf);
 
   correlator.snapshot(obuf);
@@ -131,21 +143,42 @@ int main ()
   cout << "obuf[1]: " << obuf[1] << endl;
   cout << "obuf[2]: " << obuf[2] << endl;
   cout << "obuf[3]: " << obuf[3] << endl;
-  assert(obuf[0] == 0*1 - 10*20);
-  assert(obuf[1] == 0*20 + 1*10);
-  assert(obuf[2] == 2*3 - 100*200);
-  assert(obuf[3] == 2*200 + 3*100);
+  assert(obuf[0] == 0*1 - 7*6);
+  assert(obuf[1] == 0*6 + 1*7);
+  assert(obuf[2] == 2*3 - 5*4);
+  assert(obuf[3] == 2*4 + 3*5);
 
-  correlator.snapshot_variance(obuf);
+  correlator.snapshot_variance(obufvar);
+  assert(obufvar[0] == 0);
+  assert(obufvar[1] == 0);
+  assert(obufvar[2] == 0);
+  assert(obufvar[3] == 0);
+  assert(obufvar[4] == 0);
+  assert(obufvar[5] == 0);
+
+  ibuf[0] = 4 * scale; ibuf[1] = 3 * scale; // segment 1, ch1
+  correlator.accumulate(sid1, ibuf);
+  ibuf[0] = 5 * scale; ibuf[1] = 2 * scale; // segment 1, ch2
+  correlator.accumulate(sid2, ibuf);
+  ibuf[0] = 6 * scale; ibuf[1] = 1 * scale; // segment 2, ch1
+  correlator.accumulate(sid1, ibuf);
+  ibuf[0] = 7 * scale; ibuf[1] = 0 * scale; // segment 2, ch2
+  correlator.accumulate(sid2, ibuf);
+
+  correlator.snapshot_variance(obufvar);
   cout << "snapshot variance: " << endl;
-  cout << "obuf[0]: " << obuf[0] << endl;
-  cout << "obuf[1]: " << obuf[1] << endl;
-  cout << "obuf[2]: " << obuf[2] << endl;
-  cout << "obuf[3]: " << obuf[3] << endl;
-  assert(obuf[0] == 50.5);
-  assert(obuf[1] == 0);
-  assert(obuf[2] == 5000.5);
-  assert(obuf[3] == 0);
+  cout << "obufvar[0]: " << obufvar[0] << " (goal 128)" << endl;
+  cout << "obufvar[1]: " << obufvar[1] << " (goal 1568)" << endl;
+  cout << "obufvar[2]: " << obufvar[2] << " (goal 448)" << endl;
+  cout << "obufvar[3]: " << obufvar[3] << " (goal 128)" << endl;
+  cout << "obufvar[4]: " << obufvar[4] << " (goal 1568)" << endl;
+  cout << "obufvar[5]: " << obufvar[5] << " (goal -448)" << endl;
+  assert(obufvar[0] == 128);
+  assert(obufvar[1] == 1568);
+  assert(obufvar[2] == 448);
+  assert(obufvar[3] == 128);
+  assert(obufvar[4] == 1568);
+  assert(obufvar[5] == -448);
 
   Channel ch3(2,1,1);
   int sid3 = ch3.streamID;

--- a/test/unit.cpp
+++ b/test/unit.cpp
@@ -110,6 +110,31 @@ int main ()
     cout << "}" << endl;
   }
 
-  
+  // Correlators
+  Channel ch1(1,1,1), ch2(1,2,1);
+  int sid1 = 273;
+  int sid2 = 289;
+  Correlator correlator({ch1, ch2}, 2, 1);
+
+  ibuf[0] = 0 * scale; ibuf[1] = 10 * scale; // segment 1, ch1
+  correlator.accumulate(sid1, ibuf);
+  ibuf[0] = 1 * scale; ibuf[1] = 20 * scale; // segment 1, ch2
+  correlator.accumulate(sid2, ibuf);
+  ibuf[0] = 2 * scale; ibuf[1] = 100 * scale; // segment 2, ch1
+  correlator.accumulate(sid1, ibuf);
+  ibuf[0] = 3 * scale; ibuf[1] = 200 * scale; // segment 2, ch2
+  correlator.accumulate(sid2, ibuf);
+
+  correlator.snapshot(obuf);
+  cout << "snapshot correlator: " << endl;
+  cout << "obuf[0]: " << obuf[0] << endl;
+  cout << "obuf[1]: " << obuf[1] << endl;
+  cout << "obuf[2]: " << obuf[2] << endl;
+  cout << "obuf[3]: " << obuf[3] << endl;
+  assert(obuf[0] == 0);
+  assert(obuf[1] == 200);
+  assert(obuf[2] == 6);
+  assert(obuf[3] == 20000);
+
   return 0;
 }

--- a/test/unit.cpp
+++ b/test/unit.cpp
@@ -14,6 +14,12 @@ std::ostream& hexn(std::ostream& out) {
   return out << "0x" << std::hex << std::setw(N) << std::setfill('0');
 }
 
+template <class T>
+bool vec_equal(vector<T> a, vector<T> b) {
+  return a.size() == b.size() && std::equal(a.begin(), a.end(), b.begin());
+}
+
+
 int main ()
 {
   cout << "BBN X6-1000 Library Unit Tests" << endl;
@@ -65,12 +71,45 @@ int main ()
   assert(obufvar[1] == 100);
   assert(obufvar[2] == 4);
   assert(obufvar[3] == 10000);
-  
+
   cout << "snapshot variance: " << endl;
   cout << "obufvar[0]: " << obufvar[0] << " (goal 4)" << endl;
   cout << "obufvar[1]: " << obufvar[1] << " (goal 100)" << endl;
   cout << "obufvar[2]: " << obufvar[2] << " (goal 4)" << endl;
   cout << "obufvar[3]: " << obufvar[3] << " (goal 10000)" << endl;
+
+  // Combinations test
+  vector<vector<int>> combos;
+  combos = combinations(3, 2);
+  assert(combos.size() == 3);
+  assert(vec_equal(combos[0], {0,1}));
+  assert(vec_equal(combos[1], {0,2}));
+  assert(vec_equal(combos[2], {1,2}));
+
+  combos = combinations(4,2);
+  assert(combos.size() == 6);
+  assert(vec_equal(combos[0], {0,1}));
+  assert(vec_equal(combos[1], {0,2}));
+  assert(vec_equal(combos[2], {0,3}));
+  assert(vec_equal(combos[3], {1,2}));
+  assert(vec_equal(combos[4], {1,3}));
+  assert(vec_equal(combos[5], {2,3}));
+
+  combos = combinations(4,3);
+  assert(combos.size() == 4);
+  assert(vec_equal(combos[0], {0,1,2}));
+  assert(vec_equal(combos[1], {0,1,3}));
+  assert(vec_equal(combos[2], {0,2,3}));
+  assert(vec_equal(combos[3], {1,2,3}));
+  cout << "combinations:" << endl;
+  for (int i = 0; i < combos.size(); i++) {
+    cout << "combos[" << i << "]: {";
+    for (int j = 0; j < combos[i].size(); j++) {
+      cout << combos[i][j] << ", ";
+    }
+    cout << "}" << endl;
+  }
+
   
   return 0;
 }


### PR DESCRIPTION
Adds the ability to compute correlations from enabled result streams. The strategy here is just to compute all possible combinations of enabled result streams. Since the combinations blow up quickly, and since I am using integer (effectively fixed-point) math to compute everything, I thought it prudent to limit the number of bodies included in the correlations. This is determined by the constant MAX_N_BODIES (currently = 3).

Includes some unit tests of various components used to build the correlators.

@caryan please review.