### PR TITLE
Prefix exported enums with X6_ to avoid conflicts with other libraries.

### DIFF
--- a/src/lib/X6_1000.cpp
+++ b/src/lib/X6_1000.cpp
@@ -157,7 +157,7 @@ void X6_1000::close() {
     FILE_LOG(logINFO) << "Closed connection to device " << deviceID_;
 }
 
-uint16_t X6_1000::get_firmware_version(MODULE_FIRMWARE_VERSION mod) {
+uint16_t X6_1000::get_firmware_version(X6_MODULE_FIRMWARE_VERSION mod) {
     uint32_t regVal;
     switch (mod) {
         case BBN_PG:
@@ -190,14 +190,14 @@ float X6_1000::get_logic_temperature() {
     return static_cast<float>(module_.Thermal().LogicTemperature());
 }
 
-void X6_1000::set_reference_source(REFERENCE_SOURCE ref) {
+void X6_1000::set_reference_source(X6_REFERENCE_SOURCE ref) {
     if ( refSource_ != ref ) {
         refSource_ = ref;
         needToInit_ = true;
     }
 }
 
-REFERENCE_SOURCE X6_1000::get_reference_source() {
+X6_REFERENCE_SOURCE X6_1000::get_reference_source() {
     return refSource_;
 }
 
@@ -207,12 +207,12 @@ double X6_1000::get_pll_frequency() {
     return freq;
 }
 
-void X6_1000::set_trigger_source(TRIGGER_SOURCE trgSrc) {
+void X6_1000::set_trigger_source(X6_TRIGGER_SOURCE trgSrc) {
     // cache trigger source
     triggerSource_ = trgSrc;
 }
 
-TRIGGER_SOURCE X6_1000::get_trigger_source() const {
+X6_TRIGGER_SOURCE X6_1000::get_trigger_source() const {
     return triggerSource_;
 }
 

--- a/src/lib/X6_1000.h
+++ b/src/lib/X6_1000.h
@@ -34,16 +34,16 @@ public:
 
 	float get_logic_temperature();
 
-	uint16_t get_firmware_version(MODULE_FIRMWARE_VERSION);
+	uint16_t get_firmware_version(X6_MODULE_FIRMWARE_VERSION);
 
-	void set_reference_source(REFERENCE_SOURCE ref = INTERNAL_REFERENCE);
-	REFERENCE_SOURCE get_reference_source();
+	void set_reference_source(X6_REFERENCE_SOURCE ref = INTERNAL_REFERENCE);
+	X6_REFERENCE_SOURCE get_reference_source();
 
 	/** Set Trigger source
 	 *  \param trgSrc SOFTWARE_TRIGGER || EXTERNAL_TRIGGER
 	 */
-	void set_trigger_source(TRIGGER_SOURCE trgSrc = EXTERNAL_TRIGGER);
-	TRIGGER_SOURCE get_trigger_source() const;
+	void set_trigger_source(X6_TRIGGER_SOURCE trgSrc = EXTERNAL_TRIGGER);
+	X6_TRIGGER_SOURCE get_trigger_source() const;
 
 	void set_trigger_delay(float delay = 0.0);
 
@@ -123,7 +123,7 @@ private:
 	Innovative::VeloBuffer       	outputPacket_;
 	vector<Innovative::VeloMergeParser> VMPs_; /**< Utility to convert and filter Velo stream back into VITA packets*/
 
-	TRIGGER_SOURCE triggerSource_ = EXTERNAL_TRIGGER; /**< cached trigger source */
+	X6_TRIGGER_SOURCE triggerSource_ = EXTERNAL_TRIGGER; /**< cached trigger source */
 
 	map<uint16_t, QDSPStream> activeQDSPStreams_;
 	//vector to go from VMP ordering to SID's
@@ -148,7 +148,7 @@ private:
 
 	std::array<bool, 2> activeInputChannels_;
 	std::array<bool, 4> activeOutputChannels_;
-	REFERENCE_SOURCE refSource_;
+	X6_REFERENCE_SOURCE refSource_;
 
 	void set_active_channels();
 	void log_card_info();

--- a/src/lib/X6_enums.h
+++ b/src/lib/X6_enums.h
@@ -6,7 +6,7 @@ enum ClockSource {
     INTERNAL_CLOCK        /**< Internal Generation */
 };
 
-enum REFERENCE_SOURCE {
+enum X6_REFERENCE_SOURCE {
     EXTERNAL_REFERENCE = 0,   /**< External Input */
     INTERNAL_REFERENCE        /**< Internal Generation */
 };
@@ -16,12 +16,12 @@ enum ExtSource {
     P16              /**< P16 input */
 };
 
-enum TRIGGER_SOURCE {
+enum X6_TRIGGER_SOURCE {
     SOFTWARE_TRIGGER = 0,    /**< Software generated trigger */
     EXTERNAL_TRIGGER         /**< External trigger */
 };
 
-enum MODULE_FIRMWARE_VERSION {
+enum X6_MODULE_FIRMWARE_VERSION {
     BBN_X6,
     BBN_QDSP,
     BBN_PG

--- a/src/lib/libx6adc.cpp
+++ b/src/lib/libx6adc.cpp
@@ -121,7 +121,7 @@ X6_STATUS initX6(int deviceID) {
 	return x6_call(deviceID, &X6_1000::init);
 }
 
-X6_STATUS get_firmware_version(int deviceID, MODULE_FIRMWARE_VERSION module, uint16_t* version) {
+X6_STATUS get_firmware_version(int deviceID, X6_MODULE_FIRMWARE_VERSION module, uint16_t* version) {
 	return x6_getter(deviceID, &X6_1000::get_firmware_version, version, module);
 }
 
@@ -129,19 +129,19 @@ X6_STATUS get_sampleRate(int deviceID, double* freq) {
 	return x6_getter(deviceID, &X6_1000::get_pll_frequency, freq);
 }
 
-X6_STATUS set_trigger_source(int deviceID, TRIGGER_SOURCE triggerSource) {
+X6_STATUS set_trigger_source(int deviceID, X6_TRIGGER_SOURCE triggerSource) {
 	return x6_call(deviceID, &X6_1000::set_trigger_source, triggerSource);
 }
 
-X6_STATUS get_trigger_source(int deviceID, TRIGGER_SOURCE* triggerSource) {
+X6_STATUS get_trigger_source(int deviceID, X6_TRIGGER_SOURCE* triggerSource) {
 	return x6_getter(deviceID, &X6_1000::get_trigger_source, triggerSource);
 }
 
-X6_STATUS set_reference_source(int deviceID, REFERENCE_SOURCE src) {
+X6_STATUS set_reference_source(int deviceID, X6_REFERENCE_SOURCE src) {
 	return x6_call(deviceID, &X6_1000::set_reference_source, src);
 }
 
-X6_STATUS get_reference_source(int deviceID, REFERENCE_SOURCE* src) {
+X6_STATUS get_reference_source(int deviceID, X6_REFERENCE_SOURCE* src) {
 	return x6_getter(deviceID, &X6_1000::get_reference_source, src);
 }
 

--- a/src/lib/libx6adc.h
+++ b/src/lib/libx6adc.h
@@ -29,10 +29,10 @@ extern "C" {
 
 //Add typedefs for the enums for C compatibility
 typedef enum X6_STATUS X6_STATUS;
-typedef enum REFERENCE_SOURCE REFERENCE_SOURCE;
+typedef enum X6_REFERENCE_SOURCE X6_REFERENCE_SOURCE;
 typedef struct ChannelTuple ChannelTuple;
-typedef enum TRIGGER_SOURCE TRIGGER_SOURCE;
-typedef enum MODULE_FIRMWARE_VERSION MODULE_FIRMWARE_VERSION;
+typedef enum X6_TRIGGER_SOURCE X6_TRIGGER_SOURCE;
+typedef enum X6_MODULE_FIRMWARE_VERSION X6_MODULE_FIRMWARE_VERSION;
 
 EXPORT const char* get_error_msg(X6_STATUS);
 
@@ -42,10 +42,10 @@ void cleanup() __attribute__((destructor));
 EXPORT X6_STATUS connect_x6(int);
 EXPORT X6_STATUS disconnect_x6(int);
 EXPORT X6_STATUS get_num_devices(unsigned*);
-EXPORT X6_STATUS get_firmware_version(int, MODULE_FIRMWARE_VERSION, uint16_t*);
+EXPORT X6_STATUS get_firmware_version(int, X6_MODULE_FIRMWARE_VERSION, uint16_t*);
 
-EXPORT X6_STATUS set_reference_source(int, REFERENCE_SOURCE);
-EXPORT X6_STATUS get_reference_source(int, REFERENCE_SOURCE*);
+EXPORT X6_STATUS set_reference_source(int, X6_REFERENCE_SOURCE);
+EXPORT X6_STATUS get_reference_source(int, X6_REFERENCE_SOURCE*);
 
 EXPORT X6_STATUS set_input_channel_enable(int, unsigned, bool);
 EXPORT X6_STATUS get_input_channel_enable(int, unsigned, bool*);
@@ -80,8 +80,8 @@ EXPORT X6_STATUS set_logging_level(int);
 
 /* unused/unfinished methods */
 EXPORT X6_STATUS initX6(int);
-EXPORT X6_STATUS set_trigger_source(int, TRIGGER_SOURCE);
-EXPORT X6_STATUS get_trigger_source(int, TRIGGER_SOURCE*);
+EXPORT X6_STATUS set_trigger_source(int, X6_TRIGGER_SOURCE);
+EXPORT X6_STATUS get_trigger_source(int, X6_TRIGGER_SOURCE*);
 EXPORT X6_STATUS get_sampleRate(int, double*);
 
 /* Pulse generator methods */

--- a/src/matlab/libx6adc.matlab.h
+++ b/src/matlab/libx6adc.matlab.h
@@ -26,10 +26,10 @@ extern "C" {
 
 //Add typedefs for the enums for C compatibility
 typedef enum X6_STATUS X6_STATUS;
-typedef enum REFERENCE_SOURCE REFERENCE_SOURCE;
+typedef enum X6_REFERENCE_SOURCE X6_REFERENCE_SOURCE;
 typedef struct ChannelTuple ChannelTuple;
-typedef enum TRIGGER_SOURCE TRIGGER_SOURCE;
-typedef enum MODULE_FIRMWARE_VERSION MODULE_FIRMWARE_VERSION;
+typedef enum X6_TRIGGER_SOURCE X6_TRIGGER_SOURCE;
+typedef enum X6_MODULE_FIRMWARE_VERSION X6_MODULE_FIRMWARE_VERSION;
 
 EXPORT const char* get_error_msg(X6_STATUS);
 
@@ -37,10 +37,10 @@ EXPORT const char* get_error_msg(X6_STATUS);
 EXPORT X6_STATUS connect_x6(int);
 EXPORT X6_STATUS disconnect_x6(int);
 EXPORT X6_STATUS get_num_devices(unsigned*);
-EXPORT X6_STATUS get_firmware_version(int, MODULE_FIRMWARE_VERSION, unsigned short*);
+EXPORT X6_STATUS get_firmware_version(int, X6_MODULE_FIRMWARE_VERSION, unsigned short*);
 
-EXPORT X6_STATUS set_reference_source(int, REFERENCE_SOURCE);
-EXPORT X6_STATUS get_reference_source(int, REFERENCE_SOURCE*);
+EXPORT X6_STATUS set_reference_source(int, X6_REFERENCE_SOURCE);
+EXPORT X6_STATUS get_reference_source(int, X6_REFERENCE_SOURCE*);
 
 EXPORT X6_STATUS set_input_channel_enable(int, unsigned, int);
 EXPORT X6_STATUS get_input_channel_enable(int, unsigned, int*);
@@ -74,8 +74,8 @@ EXPORT X6_STATUS set_logging_level(int);
 
 /* unused/unfinished methods */
 EXPORT X6_STATUS initX6(int);
-EXPORT X6_STATUS set_trigger_source(int, TRIGGER_SOURCE);
-EXPORT X6_STATUS get_trigger_source(int, TRIGGER_SOURCE*);
+EXPORT X6_STATUS set_trigger_source(int, X6_TRIGGER_SOURCE);
+EXPORT X6_STATUS get_trigger_source(int, X6_TRIGGER_SOURCE*);
 EXPORT X6_STATUS get_sampleRate(int, double*);
 
 /* Pulse generator methods */

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -67,7 +67,7 @@ int main ()
 
   set_trigger_source(0, EXTERNAL_TRIGGER);
 
-  TRIGGER_SOURCE triggerSource;
+  X6_TRIGGER_SOURCE triggerSource;
   get_trigger_source(0, &triggerSource);
   cout << "get trigger source returns " << ((triggerSource == SOFTWARE_TRIGGER) ? "SOFTWARE_TRIGGER" : "EXTERNAL_TRIGGER") << endl;
 


### PR DESCRIPTION
Fixes #17. Untested since I cannot compile the library on my mac.