### PR TITLE
Mutexes on RecordQueues

### DIFF
--- a/src/lib/RecordQueue.h
+++ b/src/lib/RecordQueue.h
@@ -45,8 +45,8 @@ template <class T>
 RecordQueue<T>::RecordQueue() {}
 
 template <class T>
-RecordQueue<T>::RecordQueue(const QDSPStream & stream, size_t recordLength) {
-	recordLength = stream.calc_record_length(recordLength);
+RecordQueue<T>::RecordQueue(const QDSPStream & stream, size_t recLen) {
+	recordLength = stream.calc_record_length(recLen);
 	fixed_to_float_ = stream.fixed_to_float();
 	stream_ = stream;
 }

--- a/src/lib/X6_1000.h
+++ b/src/lib/X6_1000.h
@@ -10,6 +10,7 @@
 #define X6_1000_H_
 
 #include <array>
+#include <mutex>
 
 #include "X6_enums.h"
 
@@ -142,6 +143,8 @@ private:
 	map<uint16_t, Accumulator> accumulators_;
 	map<vector<uint16_t>, Correlator> correlators_;
 	map<uint16_t, RecordQueue<int32_t>> queues_;
+	// locks for reading/writing data to queues
+	map<uint16_t, std::mutex> mutexes_;
 
 	// State Variables
 	bool isOpen_;				  /**< cached flag indicaing board was openned */


### PR DESCRIPTION
Adds some thread safety and maybe fixes a MATLAB crash.