### PR TITLE
Fix number of records sent over the socket interface

### DIFF
--- a/src/lib/RecordQueue.h
+++ b/src/lib/RecordQueue.h
@@ -36,7 +36,7 @@ class RecordQueue {
 public:
 
 	RecordQueue<T>();
-	RecordQueue<T>(const QDSPStream &, size_t);
+	RecordQueue<T>(const QDSPStream &, size_t, size_t);
 
 	template <class U>
 	void push(const Innovative::AccessDatagram<U> &);

--- a/src/lib/X6_1000.cpp
+++ b/src/lib/X6_1000.cpp
@@ -824,8 +824,12 @@ void X6_1000::initialize_queues() {
 	queues_.clear();
 	mutexes_.clear();
 	for (auto kv : activeQDSPStreams_) {
-		// queues_[kv.first] = RecordQueue<int32_t>(kv.second, recordLength_);
-		queues_.emplace(std::piecewise_construct, std::forward_as_tuple(kv.first), std::forward_as_tuple(kv.second, recordLength_));
+		// effectively:
+		// queues_[kv.first] = RecordQueue<int32_t>(kv.second, recordLength_, numRecords_);
+		// but avoids issues with std::atomics not being movable/copyable
+		queues_.emplace(std::piecewise_construct,
+			            std::forward_as_tuple(kv.first),
+			            std::forward_as_tuple(kv.second, recordLength_, numRecords_));
 		// mutexes_[kv.first] = std::mutex();
 		mutexes_.emplace(std::piecewise_construct, std::forward_as_tuple(kv.first), std::forward_as_tuple());
 		// add the socket to the RecordQueue if we have one


### PR DESCRIPTION
There was an issue where more data was arriving on the client application socket than expected. This was because of an order of operations bug where we didn't test "doneness" at the appropriate point in event path.