### PR TITLE
Update to work with latest II drivers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,13 +113,14 @@ set ( II_LIBS
 	Analysis_Mb
 	Framework_Con
 	Framework_Mb
+	Framework_Win
+	Framework_Qt
 	Utility_Mb
 	Hardware_Mb
 	Pci_Mb
 	Ficl_Mb
 	Poco_Foundation_Mb
 	Poco_Net_Mb
-	Vpx_Mb
 )
 
 # linux and mingw-64
@@ -128,7 +129,6 @@ if(NOT MSVC)
 		-Wl,--start-group
 		${II_LIBS}
 		-Wl,--end-group
-		wdapi
 		${IPP_LIB} # in Intel IPP directory listed above
 	)
 	# on Linux wdapi needs dl to dynamically load
@@ -148,12 +148,13 @@ if(MSVC)
 
 	target_link_libraries(x6
 		${IPP_LIB}
-		wdapi
+		#wdapi
 	)
 endif()
 
 if(WIN32)
 	target_link_libraries(x6
+		setupapi
 		iphlpapi # II's PocoFoundation needs GetAdaptersAddress on Windows
 		ws2_32
 	)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@ message("Using ${INNOVATIVE_PATH} as Innovative install directory")
 
 #include Malibu headers
 include_directories(${INNOVATIVE_PATH}/Malibu)
+include_directories(${INNOVATIVE_PATH}/Malibu/Poco/Foundation/include)
 
 #and our own library headers
 include_directories("./lib/")
@@ -118,6 +119,7 @@ set ( II_LIBS
 	Ficl_Mb
 	Poco_Foundation_Mb
 	Poco_Net_Mb
+	Vpx_Mb
 )
 
 # linux and mingw-64

--- a/src/lib/Accumulator.h
+++ b/src/lib/Accumulator.h
@@ -13,10 +13,14 @@
 #include "QDSPStream.h"
 
 #include <algorithm> //std::transform
+#include <vector>
+using std::vector;
+using std::max;
 
 #include "logger.h"
 
 #include <BufferDatagrams_Mb.h>
+
 
 class Accumulator{
 

--- a/src/lib/Correlator.cpp
+++ b/src/lib/Correlator.cpp
@@ -10,6 +10,7 @@
 #include "Correlator.h"
 
 #include <algorithm> //std::transform
+using std::max;
 
 Correlator::Correlator() :
     recordsTaken{0}, wfmCt_{0}, recordLength_{2}, numSegments_{0}, numWaveforms_{0} {};

--- a/src/lib/Correlator.h
+++ b/src/lib/Correlator.h
@@ -12,6 +12,8 @@
 
 #include <vector>
 using std::vector;
+#include <map>
+using std::map;
 #include <cstddef>
 
 #include "QDSPStream.h"


### PR DESCRIPTION
Updated to work with the latest drivers from Innovative Integration, as of 3/2018. 

- Fixed namespace issues and paths
- Fix linker libraries for windows.

Tested with GCC 4.2 on mingw64. Not tested with MSVC or on Linux. 