### PR TITLE
Don't merge in Windows II driver changes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,7 +15,6 @@ message("Using ${INNOVATIVE_PATH} as Innovative install directory")
 
 #include Malibu headers
 include_directories(${INNOVATIVE_PATH}/Malibu)
-include_directories(${INNOVATIVE_PATH}/Malibu/Poco/Foundation/include)
 
 #and our own library headers
 include_directories("./lib/")
@@ -113,8 +112,6 @@ set ( II_LIBS
 	Analysis_Mb
 	Framework_Con
 	Framework_Mb
-	Framework_Win
-	Framework_Qt
 	Utility_Mb
 	Hardware_Mb
 	Pci_Mb
@@ -129,6 +126,7 @@ if(NOT MSVC)
 		-Wl,--start-group
 		${II_LIBS}
 		-Wl,--end-group
+		wdapi
 		${IPP_LIB} # in Intel IPP directory listed above
 	)
 	# on Linux wdapi needs dl to dynamically load
@@ -148,13 +146,12 @@ if(MSVC)
 
 	target_link_libraries(x6
 		${IPP_LIB}
-		#wdapi
+		wdapi
 	)
 endif()
 
 if(WIN32)
 	target_link_libraries(x6
-		setupapi
 		iphlpapi # II's PocoFoundation needs GetAdaptersAddress on Windows
 		ws2_32
 	)

--- a/src/lib/Accumulator.h
+++ b/src/lib/Accumulator.h
@@ -13,14 +13,10 @@
 #include "QDSPStream.h"
 
 #include <algorithm> //std::transform
-#include <vector>
-using std::vector;
-using std::max;
 
 #include "logger.h"
 
 #include <BufferDatagrams_Mb.h>
-
 
 class Accumulator{
 

--- a/src/lib/Correlator.cpp
+++ b/src/lib/Correlator.cpp
@@ -10,7 +10,6 @@
 #include "Correlator.h"
 
 #include <algorithm> //std::transform
-using std::max;
 
 Correlator::Correlator() :
     recordsTaken{0}, wfmCt_{0}, recordLength_{2}, numSegments_{0}, numWaveforms_{0} {};

--- a/src/lib/Correlator.h
+++ b/src/lib/Correlator.h
@@ -12,8 +12,6 @@
 
 #include <vector>
 using std::vector;
-#include <map>
-using std::map;
 #include <cstddef>
 
 #include "QDSPStream.h"


### PR DESCRIPTION
Windows and Linux II drivers now separate enough that they should be on different branches.

Reverts BBN-Q/libx6#47